### PR TITLE
Optimize image size and change workdir default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ For example, if you rename the `RUN_AS_USER` to something like `bob`, `/home/bob
 #### Working with SSH
 SSH also behaves in a similar way. Keep reading below for more details.
 
-#### Mounting the `/workdir` directory
-We also have a `/workdir` directory that is intended for you your workspace.
+#### Mounting the `/app` directory
+We also have a `/app` directory that is intended for you your workspace.
 
 ### Change the "run as" user, PUID and PGID
 
@@ -59,7 +59,7 @@ We also have a `/workdir` directory that is intended for you your workspace.
 docker run --rm -it \
   -v "$HOME/.ssh:/ssh:ro" \
   -v "$HOME/.ssh/known_hosts:/ssh/known_hosts:rw" \
-  -v "$(pwd):/workdir" \
+  -v "$(pwd):/app" \
   -v "$HOME/.config/gh:/config/gh:rw" \
   -e "PUID=9999" \
   -e "PGID=9999" \
@@ -71,7 +71,7 @@ docker run --rm -it \
 ```bash
 docker run --rm -it \
   -v "$HOME/.ssh:/ssh" \
-  -v "$(pwd):/workdir" \
+  -v "$(pwd):/app" \
   serversideup/github-cli:latest /bin/sh
 ```
 
@@ -92,7 +92,7 @@ The SSH auth socket is a Unix socket used by the SSH agent to communicate with o
 docker run --rm -it \
   -v "$HOME/.ssh:/ssh:ro" \
   -v "$HOME/.ssh/known_hosts:/ssh/known_hosts:rw" \
-  -v "$(pwd):/workdir" \
+  -v "$(pwd):/app" \
   -v "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock" \
   -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" \
   serversideup/github-cli:latest gh --version
@@ -105,7 +105,7 @@ Notice how we're matching the `SSH_AUTH_SOCK` to the host's socket. This is nece
 docker run --rm -it \
   -v "$HOME/.ssh:/ssh:ro" \
  -v "$HOME/.ssh/known_hosts:/ssh/known_hosts:rw" \
-  -v "$(pwd):/workdir" \
+  -v "$(pwd):/app" \
   -v "$SSH_AUTH_SOCK:$SSH_AUTH_SOCK" \
   -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK" \
   serversideup/github-cli:latest gh --version

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -6,7 +6,7 @@ ARG ALPINE_DEPENDENCIES="curl,git,ca-certificates,su-exec,openssh-client,shadow,
 ARG DEBIAN_DEPENDENCIES="curl,git,ca-certificates,gosu,openssh-client,sshpass"
 ARG PUID='1000'
 ARG PGID='1000'
-ARG GITHUB_WORK_DIR='/workdir'
+ARG GITHUB_WORK_DIR='/app'
 ARG REPOSITORY_BUILD_VERSION='dev'
 
 COPY --chown=root:root --chmod=755 src/rootfs /
@@ -47,6 +47,6 @@ LABEL org.opencontainers.image.title="serversideup/github-cli" \
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-WORKDIR /workdir
+WORKDIR /app
 
 CMD ["gh"]

--- a/src/rootfs/entrypoint.sh
+++ b/src/rootfs/entrypoint.sh
@@ -84,7 +84,7 @@ if { [ ! -z "${PUID}" ] && [ "${PUID}" != "$default_uid" ]; } || { [ ! -z "${PGI
     groupmod -g "${PGID}" "${run_as_user}" 2>&1 >/dev/null || echo "Error changing group ID."
 
     debug_print "Changing ownership of all files and directories..."
-    chown "${PUID}:${PGID}" "/home/${run_as_user}" "/workdir" "/config"
+    chown "${PUID}:${PGID}" "/home/${run_as_user}" "/app" "/config"
 
 fi
 

--- a/src/rootfs/usr/local/bin/serversideup-create-unprivileged-user
+++ b/src/rootfs/usr/local/bin/serversideup-create-unprivileged-user
@@ -26,10 +26,10 @@ if [ -f /etc/alpine-release ]; then
     # Alpine
     addgroup -g "${PGID}" "${username}" && \
     adduser -u "${PUID}" -G "${username}" -h "/home/${username}" -D "${username}"
-    su-exec "${username}" git config --global --add safe.directory "/workdir"
+    su-exec "${username}" git config --global --add safe.directory "/app"
 else
     # Debian
     addgroup --gid "${PGID}" "${username}" && \
     adduser --uid "${PUID}" --gid "${PGID}" --home "/home/${username}" --disabled-password --gecos '' "${username}"
-    gosu "${username}" git config --global --add safe.directory "/workdir"
+    gosu "${username}" git config --global --add safe.directory "/app"
 fi

--- a/src/rootfs/usr/local/bin/serversideup-install-github-cli
+++ b/src/rootfs/usr/local/bin/serversideup-install-github-cli
@@ -36,6 +36,6 @@ tar -xzf "gh_${VERSION}_linux_${ARCH}.tar.gz"
 mv "gh_${VERSION}_linux_${ARCH}/bin/gh" /usr/local/bin/gh
 
 # Cleanup
-rm -rf "gh_${VERSION}_linux_${ARCH}" gh.tar.gz checksums.txt
+rm -rf "gh_${VERSION}_linux_${ARCH}" "gh_${VERSION}_linux_${ARCH}.tar.gz" checksums.txt
 
 echo "⚡️ GitHub CLI installation completed"


### PR DESCRIPTION
# What this PR does
- It removes some files that were accidentally left behind during install, reducing the image size
- It changes the default `/workdir` to `/app` because some users we're being confused by the defaults during `gh repo create`